### PR TITLE
Version 2.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,24 +19,12 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cython >=0.29,!=0.29.18,!=0.29.31
-    - numpy 1.21.2  # [py<310]
-    - numpy 1.21.6  # [py310 and unix]
-    - numpy 1.22.3  # [py310 and win]
-    - numpy 1.23.2  # [py311]
-    - numpy 1.26.0  # [py312]
-    - scipy 1.3.2  # [py<=38]
-    - scipy 1.5.3  # [py<=38 and aarch64]
-    - scipy 1.5.4  # [py39]
-    - scipy 1.7.2  # [py310]
-    - scipy 1.9.3  # [py311]
-    - scipy 1.11.2  # [py312]
-    - statsmodels 0.13.2  # [py<=310]
-    - statsmodels 0.13.3  # [py311]
-    - statsmodels 0.14.0  # [py312]
+    - numpy {{ numpy }}
     - pip
     - python
     - setuptools
     - wheel
+    - packaging
   run:
     - python
     - joblib >=0.11
@@ -49,7 +37,7 @@ requirements:
     - urllib3
     - setuptools >=38.6.0,!=50.0.0
     # Bundled with setuptools, but want to be explicit
-    # - packaging >=17.1
+    - packaging >=17.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,23 +19,37 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cython >=0.29,!=0.29.18,!=0.29.31
-    - numpy   1.21  # [py<311]
-    - numpy   1.23  # [py==311]
+    - numpy 1.21.2  # [py<310]
+    - numpy 1.21.6  # [py310 and unix]
+    - numpy 1.22.3  # [py310 and win]
+    - numpy 1.23.2  # [py311]
+    - numpy 1.26.0  # [py312]
+    - scipy 1.3.2  # [py<=38]
+    - scipy 1.5.3  # [py<=38 and aarch64]
+    - scipy 1.5.4  # [py39]
+    - scipy 1.7.2  # [py310]
+    - scipy 1.9.3  # [py311]
+    - scipy 1.11.2  # [py312]
+    - statsmodels 0.13.2  # [py<=310]
+    - statsmodels 0.13.3  # [py311]
+    - statsmodels 0.14.0  # [py312]
     - pip
     - python
     - setuptools
     - wheel
   run:
-    - cython >=0.29,!=0.29.18,!=0.29.31
+    - python
     - joblib >=0.11
+    - cython >=0.29,!=0.29.18,!=0.29.31
     - {{ pin_compatible('numpy') }}
     - pandas >=0.19
-    - python
     - scikit-learn >=0.22
     - scipy >=1.3.2
-    - setuptools >=38.6.0,!=50.0.0
     - statsmodels >=0.13.2
     - urllib3
+    - setuptools >=38.6.0,!=50.0.0
+    # Bundled with setuptools, but want to be explicit
+    # - packaging >=17.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,3 +67,6 @@ extra:
     - tomasvanpottelbergh
     - cdesouza21
     - bkreider
+  skip-lints:
+    - python_build_tool_in_run
+    - cython_must_be_in_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pmdarima" %}
-{% set version = "2.0.3" %}
+{% set version = "2.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 91acb3f7c12f3cfd6263efe323d3b8f94b58dcd242d68f11560a6c717001b01f
+  sha256: b87f9d9f5b7dc2ddbd053687c2264e26ac98fd4118e843c7e9bc3dd7343e5c1a
 
 build:
   number: 0


### PR DESCRIPTION
pmdarima 2.0.4

**Destination channel:** defaults

### Links

- [PKG-4183](https://anaconda.atlassian.net/browse/PKG-4183)
- [Upstream repository](https://github.com/alkaline-ml/pmdarima/tree/v2.0.4)
- [Upstream changelog/diff](https://github.com/alkaline-ml/pmdarima/releases)

### Explanation of changes:

- Update version and sha256
- Update dependencies
- Skip some lints for cleanliness


[PKG-4183]: https://anaconda.atlassian.net/browse/PKG-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ